### PR TITLE
Allow custom http clients

### DIFF
--- a/hmkit-fleet/build.gradle
+++ b/hmkit-fleet/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     }
 
     // web
-    implementation('com.squareup.okhttp3:okhttp:4.10.0')
+    api('com.squareup.okhttp3:okhttp:4.10.0')
 
     // Koin
     implementation "io.insert-koin:koin-core:$koinVersion"

--- a/hmkit-fleet/src/main/kotlin/HMKitConfiguration.kt
+++ b/hmkit-fleet/src/main/kotlin/HMKitConfiguration.kt
@@ -1,0 +1,25 @@
+package com.highmobility.hmkitfleet
+
+import okhttp3.OkHttpClient
+
+class HMKitConfiguration private constructor(builder: Builder) {
+    val client: OkHttpClient
+
+    init {
+        client = builder.client ?: OkHttpClient()
+    }
+
+    class Builder {
+        var client: OkHttpClient? = null
+            private set
+
+        fun client(client: OkHttpClient) = apply { this.client = client }
+        fun build() = HMKitConfiguration(this)
+    }
+
+    companion object {
+        fun defaultConfiguration(): HMKitConfiguration {
+            return Builder().build()
+        }
+    }
+}

--- a/hmkit-fleet/src/main/kotlin/HMKitFleet.kt
+++ b/hmkit-fleet/src/main/kotlin/HMKitFleet.kt
@@ -49,7 +49,7 @@ class HMKitFleet @JvmOverloads constructor(
     val environment: Environment = Environment.PRODUCTION,
 
     /**
-     * More options for configuring the HMKit. Default is [HMKitConfiguration.defaultConfiguration].
+     * More options for configuring the HMKit. Use the [HMKitConfiguration.Builder] to create the object.
      */
     hmKitConfiguration: HMKitConfiguration = HMKitConfiguration.defaultConfiguration()
 ) {

--- a/hmkit-fleet/src/main/kotlin/HMKitFleet.kt
+++ b/hmkit-fleet/src/main/kotlin/HMKitFleet.kt
@@ -42,12 +42,18 @@ class HMKitFleet @JvmOverloads constructor(
      * The configuration for the Fleet SDK. Get the values from the High-Mobility console.
      */
     configuration: ServiceAccountApiConfiguration,
+
     /**
      * The SDK environment. Default is Production.
      */
-    val environment: Environment = Environment.PRODUCTION
+    val environment: Environment = Environment.PRODUCTION,
+
+    /**
+     * More options for configuring the HMKit. Default is [HMKitConfiguration.defaultConfiguration].
+     */
+    hmKitConfiguration: HMKitConfiguration = HMKitConfiguration.defaultConfiguration()
 ) {
-    private val koin = Modules(configuration, environment).start()
+    private val koin = Modules(configuration, environment, hmKitConfiguration).start()
     private val logger by koin.inject<Logger>()
 
     /**

--- a/hmkit-fleet/src/main/kotlin/Koin.kt
+++ b/hmkit-fleet/src/main/kotlin/Koin.kt
@@ -40,11 +40,12 @@ import org.slf4j.LoggerFactory
 
 internal class Modules(
     configuration: ServiceAccountApiConfiguration,
-    environment: HMKitFleet.Environment
+    environment: HMKitFleet.Environment,
+    hmKitConfiguration: HMKitConfiguration
 ) {
     private val koinModules = module {
         single { LoggerFactory.getLogger(HMKitFleet::class.java) }
-        single { OkHttpClient() }
+        single { hmKitConfiguration.client }
         single { environment }
         single { Crypto() }
         single { Requests(get(), get(), environment.url) }

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/BaseTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/BaseTest.kt
@@ -61,17 +61,6 @@ internal fun expiredAuthToken(): AuthToken {
     )
 }
 
-internal val mockSignature = mockk<Signature> {
-    every { base64UrlSafe } returns "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg=="
-    every { base64 } returns "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg=="
-    every { hex } returns "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-}
-
-internal val mockSerial = mockk<DeviceSerial> {
-    every { hex } returns "AAAAAAAAAAAAAAAAAA"
-    every { base64 } returns "qqqqqqqqqqqq"
-}
-
 internal val newAccessToken: AccessToken = Json.decodeFromString(
     "{\n" +
         "  \"token_type\": \"bearer\",\n" +
@@ -80,18 +69,6 @@ internal val newAccessToken: AccessToken = Json.decodeFromString(
         "  \"expires_in\": 600,\n" +
         "  \"access_token\": \"a50e89e5-093c-4727-8101-4c6e81addabe\"\n" +
         "}"
-)
-
-internal val mockAccessCert = mockk<AccessCertificate> {
-    every { hex } returns "01030000030400000000000000040500000000000000050600000000000000000600000000000006000000000000000006000000000000060000000000000000060000000000000600000000000000000600000000000607010203070804050609090A0A0A0A0A0A0A0A0A0B00000000000000000600000000000006000000000000000006000000000000060000000000000000060000000000000600000000000000000600000000000B"
-    every { base64 } returns "AQMAAAMEAAAAAAAAAAQFAAAAAAAAAAUGAAAAAAAAAAAGAAAAAAAABgAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAGAAAAAAAGBwECAwcIBAUGCQkKCgoKCgoKCgoLAAAAAAAAAAAGAAAAAAAABgAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAGAAAAAAAL"
-    every { gainerSerial } returns mockSerial
-}
-
-internal val newVehicleAccess = VehicleAccess(
-    testVin,
-    newAccessToken,
-    mockAccessCert
 )
 
 open class BaseTest : KoinTest {
@@ -123,6 +100,30 @@ open class BaseTest : KoinTest {
     }
 
     val mockLogger = mockk<Logger>()
+
+    // have to be in base so they are created again for each test class
+    internal val mockSignature = mockk<Signature> {
+        every { base64UrlSafe } returns "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg=="
+        every { base64 } returns "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg=="
+        every { hex } returns "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    }
+
+    internal val mockSerial = mockk<DeviceSerial> {
+        every { hex } returns "AAAAAAAAAAAAAAAAAA"
+        every { base64 } returns "qqqqqqqqqqqq"
+    }
+
+    internal val mockAccessCert = mockk<AccessCertificate> {
+        every { hex } returns "01030000030400000000000000040500000000000000050600000000000000000600000000000006000000000000000006000000000000060000000000000000060000000000000600000000000000000600000000000607010203070804050609090A0A0A0A0A0A0A0A0A0B00000000000000000600000000000006000000000000000006000000000000060000000000000000060000000000000600000000000000000600000000000B"
+        every { base64 } returns "AQMAAAMEAAAAAAAAAAQFAAAAAAAAAAUGAAAAAAAAAAAGAAAAAAAABgAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAGAAAAAAAGBwECAwcIBAUGCQkKCgoKCgoKCgoLAAAAAAAAAAAGAAAAAAAABgAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAGAAAAAAAL"
+        every { gainerSerial } returns mockSerial
+    }
+
+    internal val newVehicleAccess = VehicleAccess(
+        testVin,
+        newAccessToken,
+        mockAccessCert
+    )
 
     @BeforeEach
     fun before() {

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitConfigurationTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitConfigurationTest.kt
@@ -1,0 +1,48 @@
+package com.highmobility.hmkitfleet.com.highmobility.hmkitfleet
+
+import com.highmobility.hmkitfleet.BaseTest
+import com.highmobility.hmkitfleet.HMKitConfiguration
+import com.highmobility.hmkitfleet.HMKitFleet
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HMKitConfigurationTest : BaseTest() {
+    @Test
+    fun customHttpClientTest() {
+        val call = mockk<Call> {
+            every {
+                enqueue(any())
+            } answers {
+                firstArg<Callback>().onResponse(
+                    this@mockk,
+                    mockk(relaxed = true)
+                )
+            }
+        }
+
+        val client = mockk<OkHttpClient> {
+            every { newCall(any()) } returns call
+        }
+        val hmkitConf = HMKitConfiguration.Builder().client(client).build()
+
+        val hmkit = HMKitFleet(
+            configuration,
+            HMKitFleet.Environment.SANDBOX,
+            hmkitConf
+        )
+
+        // verify mock without throwing succeeds
+        hmkit.getClearanceStatus("vin1").get()
+
+        // now throw exception on new call and verify it is thrown
+        every { client.newCall(any()) } throws Exception("test")
+        assertThrows<Exception> {
+            hmkit.getClearanceStatus("vin1").get()
+        }
+    }
+}

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitFleetTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitFleetTest.kt
@@ -24,6 +24,7 @@
 
 package com.highmobility.hmkitfleet
 
+import com.highmobility.hmkitfleet.model.Brand
 import com.highmobility.hmkitfleet.model.ClearanceStatus
 import com.highmobility.hmkitfleet.model.RequestClearanceResponse
 import com.highmobility.hmkitfleet.network.AccessCertificateRequests
@@ -38,6 +39,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -46,6 +49,7 @@ import org.koin.core.context.stopKoin
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.slf4j.Logger
+import java.net.HttpURLConnection
 
 class HMKitFleetTest : BaseTest() {
     private val accessCertificateRequests = mockk<AccessCertificateRequests>()
@@ -166,7 +170,7 @@ class HMKitFleetTest : BaseTest() {
         assertTrue(clearance.response?.status == ClearanceStatus.Status.REVOKING)
     }
 
-/*    @Test
+    @Test
     fun canSetCustomWebUrl() {
         stopKoin()
         clearAllMocks()
@@ -179,7 +183,7 @@ class HMKitFleetTest : BaseTest() {
                 .setResponseCode(HttpURLConnection.HTTP_CREATED)
         )
 
-        val fakeUrl = mockWebServer.url("").toString()
+        val fakeUrl = mockWebServer.url("canSetCustomWebUrl").toString()
 
         HMKitFleet.Environment.webUrl = fakeUrl
         assertTrue(HMKitFleet.Environment.webUrl == fakeUrl)
@@ -191,5 +195,5 @@ class HMKitFleetTest : BaseTest() {
         assertTrue(recordedRequest.requestUrl.toString().contains(fakeUrl))
 
         mockWebServer.shutdown()
-    }*/
+    }
 }

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitFleetTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/HMKitFleetTest.kt
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.highmobility.hmkitfleet
 
 import com.highmobility.hmkitfleet.model.Brand
@@ -38,7 +37,10 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -51,6 +53,7 @@ import org.koin.dsl.module
 import org.slf4j.Logger
 import java.net.HttpURLConnection
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HMKitFleetTest : BaseTest() {
     private val accessCertificateRequests = mockk<AccessCertificateRequests>()
     private val accessTokenRequests = mockk<AccessTokenRequests>()
@@ -74,7 +77,11 @@ class HMKitFleetTest : BaseTest() {
     @AfterEach
     fun tearDown() {
         stopKoin()
+        unmockkConstructor(Modules::class)
+        clearAllMocks()
     }
+
+    // this or any other single runBlocking test somehow messes up telematicsRequestTest
 
     @Test
     fun testGetVehicleAccessRequests() = runBlocking {
@@ -90,7 +97,6 @@ class HMKitFleetTest : BaseTest() {
 
         val hmkit = HMKitFleet(mockk())
         val access = hmkit.getVehicleAccess("vin1").get()
-
         coVerify { accessCertificateRequests.getAccessCertificate(any()) }
         coVerify { accessTokenRequests.getAccessToken(any()) }
 

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/AccessCertificateRequestsTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/AccessCertificateRequestsTest.kt
@@ -27,9 +27,6 @@ import com.highmobility.crypto.Crypto
 import com.highmobility.crypto.value.PrivateKey
 import com.highmobility.hmkitfleet.ClientCertificate
 import com.highmobility.hmkitfleet.BaseTest
-import com.highmobility.hmkitfleet.mockAccessCert
-import com.highmobility.hmkitfleet.mockSerial
-import com.highmobility.hmkitfleet.mockSignature
 import com.highmobility.hmkitfleet.newAccessToken
 import com.highmobility.value.Bytes
 import io.mockk.every

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/AuthTokenRequestsTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/AuthTokenRequestsTest.kt
@@ -25,8 +25,6 @@ package com.highmobility.hmkitfleet.network
 
 import com.highmobility.crypto.Crypto
 import com.highmobility.hmkitfleet.BaseTest
-import com.highmobility.hmkitfleet.HMKitFleet
-import com.highmobility.hmkitfleet.mockSignature
 import com.highmobility.hmkitfleet.model.AuthToken
 import com.highmobility.hmkitfleet.notExpiredAuthToken
 import com.highmobility.utils.Base64
@@ -131,9 +129,9 @@ internal class AuthTokenRequestsTest : BaseTest() {
             .setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED)
             .setBody(
                 "{\"errors\":" +
-                        "[{\"detail\":\"Missing or invalid assertion. It must be a JWT signed with the service account key.\"," +
-                        "\"source\":\"assertion\"," +
-                        "\"title\":\"Not authorized\"}]}"
+                    "[{\"detail\":\"Missing or invalid assertion. It must be a JWT signed with the service account key.\"," +
+                    "\"source\":\"assertion\"," +
+                    "\"title\":\"Not authorized\"}]}"
             )
         mockWebServer.enqueue(mockResponse)
         val baseUrl: HttpUrl = mockWebServer.url("")

--- a/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/TelematicsRequestsTest.kt
+++ b/hmkit-fleet/src/test/kotlin/com/highmobility/hmkitfleet/network/TelematicsRequestsTest.kt
@@ -26,14 +26,13 @@ package com.highmobility.hmkitfleet.network
 import com.highmobility.autoapi.Diagnostics
 import com.highmobility.autoapi.property.Property
 import com.highmobility.autoapi.value.measurement.Length
+import com.highmobility.crypto.AccessCertificate
 import com.highmobility.crypto.Crypto
 import com.highmobility.crypto.value.DeviceSerial
 import com.highmobility.crypto.value.Issuer
 import com.highmobility.crypto.value.PrivateKey
 import com.highmobility.hmkitfleet.BaseTest
 import com.highmobility.hmkitfleet.ClientCertificate
-import com.highmobility.hmkitfleet.mockAccessCert
-import com.highmobility.hmkitfleet.mockSignature
 import com.highmobility.value.Bytes
 import io.mockk.every
 import io.mockk.mockk
@@ -73,16 +72,18 @@ internal class TelematicsRequestsTest : BaseTest() {
         every { issuer } returns Issuer("00000000")
     }
 
-    private val crypto = mockk<Crypto> {
+    private val crypto = mockk<Crypto>().also {
         // random encryption ok here
         every {
-            createTelematicsContainer(
+            it.createTelematicsContainer(
                 Diagnostics.GetState(), privateKey, certificate.serial, mockAccessCert, nonce
             )
         } returns encryptedSentCommand
 
+        println("mock ${Diagnostics.GetState()} ${privateKey} ${certificate.serial} ${mockAccessCert} ${nonce}")
+
         every {
-            getPayloadFromTelematicsContainer(
+            it.getPayloadFromTelematicsContainer(
                 Bytes(encryptedReceivedCommand), privateKey, mockAccessCert
             )
         } returns decryptedReceivedCommand
@@ -227,7 +228,13 @@ internal class TelematicsRequestsTest : BaseTest() {
 
         val crypto = mockk<Crypto> {
             every {
-                createTelematicsContainer(Diagnostics.GetState(), privateKey, certificate.serial, mockAccessCert, nonce)
+                createTelematicsContainer(
+                    Diagnostics.GetState(),
+                    privateKey,
+                    certificate.serial,
+                    mockAccessCert,
+                    nonce
+                )
             } returns encryptedSentCommand
         }
 
@@ -261,7 +268,13 @@ internal class TelematicsRequestsTest : BaseTest() {
 
         val crypto = mockk<Crypto> {
             every {
-                createTelematicsContainer(Diagnostics.GetState(), privateKey, certificate.serial, mockAccessCert, nonce)
+                createTelematicsContainer(
+                    Diagnostics.GetState(),
+                    privateKey,
+                    certificate.serial,
+                    mockAccessCert,
+                    nonce
+                )
             } returns encryptedSentCommand
         }
 
@@ -295,7 +308,13 @@ internal class TelematicsRequestsTest : BaseTest() {
             Bytes("AAKmNHIgCtR0hrKisC6a185zHW9RLMFyrZr3vEH+AP4AAQH+AP4A/gAF0sTqC04m6PDp6NXc1fRzPSsWCLajtlYraiDimxVTZQqrbo+8/v//")
         val crypto = mockk<Crypto> {
             every {
-                createTelematicsContainer(Diagnostics.GetState(), privateKey, certificate.serial, mockAccessCert, nonce)
+                createTelematicsContainer(
+                    Diagnostics.GetState(),
+                    privateKey,
+                    certificate.serial,
+                    mockAccessCert,
+                    nonce
+                )
             } returns encryptedSentCommand
 
             // fail the response parsing


### PR DESCRIPTION
### Why add a configurable HTTP client?

Our customers could 

- intercept the requests in order to log them
    - slf4j logging interface is static, and doesn’t allow differentiating between HMKit instances.
- configure the client to use a proxy
- use a mock client in tests

### Changes to HMKitFleet

We already released a version that uses constructor like this

```solidity
HMKitFleet hmkit = new HMKitFleet(
  apiConfiguration,
  HMKitFleet.Environment.SANDBOX
);
```

Now looking at this, we could keep adding constructor parameters. But this can get messy if we add more things in the future. For example, AWS lib has 9 different builder options.

My suggestion is to keep the first 2 parameters as they are, and add a third one: `HMKitFleetConfiguration` object. This would be created with Builder pattern, so we can add properties later.

```java
HMKitConfiguration hmkitConfiguration = new HMKitConfiguration.Builder()
  .client(new OkHttpClient())
  .build();

HMKitFleet hmkitOne = new HMKitFleet(
  apiConfiguration,
  HMKitFleet.Environment.SANDBOX,
  hmkitConfiguration
);
```

Note: we could add the `Environment` to this new object as well. But we already released the v1. So we can keep the environment as the second parameter. It is quite generally used parameter. So it can be in the constructer.

### Adding new clients in the future

With this PR, we only support `OKHttpClient`. This client is implemented in `HMKitFleet` without any abstractions(in line).

To add new clients in the future, we would need to define a general `SdkHttpClient` interface, which different clients could implement. We would need to implement this interface for different clients, for instance `OkHttpSdkHttpClient` and `ApacheSdkHttpClient`. Customers could include their preferred client in their own dependencies.

This requires bigger refactoring and we could investigate this architecture in another v2 release. Plan is to currently only support OkHttpClient.